### PR TITLE
Fix/adjust pass submission;

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -214,4 +214,5 @@ function lovr.draw( pass )
 	UI.End( pass )
 
 	UI.RenderFrame( pass )
+	return true
 end

--- a/ui/ui.lua
+++ b/ui/ui.lua
@@ -294,8 +294,9 @@ local function UpdateLayout( bbox )
 	layout.same_line = false
 end
 
-local function GenerateOSKTextures( pass )
+local function GenerateOSKTextures()
 	-- TODO: Fix code repetition
+	local passes = {}
 	for md = 1, 3 do
 		local p = lovr.graphics.getPass( 'render', osk.textures[ md ] )
 		p:setFont( font.handle )
@@ -399,8 +400,9 @@ local function GenerateOSKTextures( pass )
 		end
 
 		p:plane( m, "fill" )
-		lovr.graphics.submit( p )
+		table.insert(passes, p)
 	end
+	return passes
 end
 
 local function ShowOSK( pass )
@@ -659,7 +661,9 @@ function UI.RenderFrame( main_pass )
 	end
 
 	if theme_changed then
-		GenerateOSKTextures( main_pass )
+		for i, p in ipairs(GenerateOSKTextures()) do
+			table.insert(passes, p)
+		end
 		theme_changed = false
 	end
 


### PR DESCRIPTION
When lovr.graphics.submit is called, it invalidates all of the passes that were created that frame.  Generally this is supposed to be called once or twice each frame to submit all of the passes, since submission is not a lightweight call.

Currently `GenerateOSKTextures` individually submits 1 pass for each keyboard mode, which will invalidate the other passes that are about to be submitted by `RenderFrame` (i.e. main_pass).  This patch changes it to instead return a table of passes that gets added to the list of passes that `RenderFrame` submits.

It may also be good to do this same thing to `RenderFrame`, where instead of submitting the passes it just returns them to the caller.  However, I didn't do that here since it would be a change to the external API and probably needs more discussion.

The demo also returns true from `lovr.draw` now so that the main pass doesn't get submitted twice.  Annoyingly, LÖVR doesn't complain about this right now (fix incoming).