### PR TITLE
Fix require path;

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,2 +1,2 @@
-local root = (...):match('(.-)[^%./]*$')
-return require(root .. '/ui/ui')
+local root = (...):gsub('/', '.'):gsub('%.init$', '')
+return require(root .. '.ui.ui')


### PR DESCRIPTION
I'm not sure what I was thinking here.  The pattern was stripping off everything before the last part of the require path (so `require('libs/lovr-ui')` -> `libs`) and then appending `/ui/ui` to that (so `libs/ui/ui`, which doesn't work).  Instead, it should *append* the ui paths, after shaving off the `.init` if it's there.  I also normalized to dots which is preferred (fervently) by some over slashes.